### PR TITLE
Replace Python CLI with BoomSky single-page web app (Pacers spoiler filter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # BoomSky
+
+BoomSky is a clean, single-page web app that reads your Bluesky timeline and hides
+Indiana Pacers spoilers unless you confirm you're caught up.
+
+## Quick start
+
+1. Run a local static server from the repo root:
+
+   ```bash
+   python3 -m http.server 5173
+   ```
+
+2. Open the app at <http://localhost:5173>.
+3. Enter your Bluesky handle + app password and choose whether you're caught up.
+
+## Notes
+
+- Use a Bluesky app password from your account settings.
+- If the Bluesky API blocks browser requests in your environment, try another browser or
+  run the app from a trusted local domain.
+- Pacers-related posts are filtered using common keywords (team name and key players).

--- a/app.js
+++ b/app.js
@@ -1,0 +1,146 @@
+const API_BASE = "https://bsky.social/xrpc";
+const PACERS_KEYWORDS = [
+  "pacers",
+  "indiana pacers",
+  "haliburton",
+  "tyrese",
+  "turner",
+  "siakam",
+  "carlisle",
+  "fieldhouse",
+];
+
+const form = document.getElementById("credentials-form");
+const timeline = document.getElementById("timeline");
+const statusPill = document.getElementById("status-pill");
+const postTemplate = document.getElementById("post-template");
+
+const setStatus = (text) => {
+  statusPill.textContent = text;
+};
+
+const showError = (message) => {
+  timeline.innerHTML = "";
+  const error = document.createElement("div");
+  error.className = "error";
+  error.textContent = message;
+  timeline.appendChild(error);
+};
+
+const showEmpty = (message) => {
+  timeline.innerHTML = "";
+  const empty = document.createElement("div");
+  empty.className = "empty";
+  empty.textContent = message;
+  timeline.appendChild(empty);
+};
+
+const containsPacersSpoiler = (text) => {
+  const lowered = text.toLowerCase();
+  return PACERS_KEYWORDS.some((keyword) => lowered.includes(keyword));
+};
+
+const formatDate = (value) => {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  return date.toLocaleString();
+};
+
+const renderPosts = (posts) => {
+  timeline.innerHTML = "";
+  if (posts.length === 0) {
+    showEmpty("No posts to show after filtering.");
+    return;
+  }
+
+  posts.forEach((item) => {
+    const post = item.post || {};
+    const record = post.record || {};
+    const author = post.author || {};
+    const clone = postTemplate.content.cloneNode(true);
+
+    clone.querySelector(".post-author").textContent = author.displayName || "Unknown";
+    clone.querySelector(".post-handle").textContent = `@${author.handle || "unknown"}`;
+    clone.querySelector(".post-date").textContent = formatDate(record.createdAt);
+    clone.querySelector(".post-text").textContent = record.text || "";
+
+    timeline.appendChild(clone);
+  });
+};
+
+const createSession = async (handle, appPassword) => {
+  const response = await fetch(`${API_BASE}/com.atproto.server.createSession`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      identifier: handle,
+      password: appPassword,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to sign in. Check your handle and app password.");
+  }
+
+  const payload = await response.json();
+  return payload.accessJwt;
+};
+
+const fetchTimeline = async (token, limit) => {
+  const response = await fetch(`${API_BASE}/app.bsky.feed.getTimeline?limit=${limit}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to load timeline. Please try again.");
+  }
+
+  const payload = await response.json();
+  return payload.feed || [];
+};
+
+const filterTimeline = (feed, hidePacers) => {
+  if (!hidePacers) {
+    return feed;
+  }
+
+  return feed.filter((item) => {
+    const text = item.post?.record?.text || "";
+    return !containsPacersSpoiler(text);
+  });
+};
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  setStatus("Loading timeline...");
+  timeline.innerHTML = "";
+
+  const formData = new FormData(form);
+  const handle = formData.get("handle").trim();
+  const appPassword = formData.get("appPassword").trim();
+  const limit = Number(formData.get("limit")) || 30;
+  const caughtUp = formData.get("caughtUp") === "yes";
+
+  if (!handle || !appPassword) {
+    showError("Please enter your handle and app password.");
+    setStatus("Waiting for sign-in");
+    return;
+  }
+
+  try {
+    const token = await createSession(handle, appPassword);
+    const feed = await fetchTimeline(token, limit);
+    const filtered = filterTimeline(feed, !caughtUp);
+    renderPosts(filtered);
+    setStatus(caughtUp ? "Showing all posts" : "Spoilers hidden");
+  } catch (error) {
+    showError(error.message);
+    setStatus("Sign-in error");
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BoomSky</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">BoomSky</p>
+          <h1>Bluesky with spoiler control</h1>
+          <p class="subtitle">
+            Check in on your Pacers watch status before pulling in your timeline, so you
+            can avoid spoilers when you&apos;re behind.
+          </p>
+        </div>
+        <div class="hero-card">
+          <p class="label">Pacers spoiler shield</p>
+          <p class="hero-value">Active when you&apos;re not caught up</p>
+        </div>
+      </header>
+
+      <main class="content">
+        <section class="card">
+          <h2>Sign in to Bluesky</h2>
+          <p class="muted">
+            Use an app password from your Bluesky account settings. We only use it to
+            fetch your timeline in this session.
+          </p>
+          <form id="credentials-form">
+            <label class="field">
+              <span>Handle</span>
+              <input
+                type="text"
+                name="handle"
+                placeholder="you.bsky.social"
+                autocomplete="username"
+                required
+              />
+            </label>
+            <label class="field">
+              <span>App password</span>
+              <input
+                type="password"
+                name="appPassword"
+                placeholder="xxxx-xxxx-xxxx-xxxx"
+                autocomplete="current-password"
+                required
+              />
+            </label>
+            <label class="field">
+              <span>Timeline posts to fetch</span>
+              <input type="number" name="limit" min="5" max="100" value="30" />
+            </label>
+
+            <fieldset class="field">
+              <legend>Are you up-to-date on Pacers games?</legend>
+              <div class="radio-row">
+                <label class="radio">
+                  <input type="radio" name="caughtUp" value="yes" />
+                  <span>Yes, I&apos;m caught up</span>
+                </label>
+                <label class="radio">
+                  <input type="radio" name="caughtUp" value="no" checked />
+                  <span>No, hide spoilers</span>
+                </label>
+              </div>
+            </fieldset>
+
+            <button type="submit" class="primary">Load timeline</button>
+          </form>
+          <p class="footnote">
+            Tip: if Bluesky&apos;s API blocks browser requests, run this page from a local
+            static server (e.g. <code>python3 -m http.server</code>).
+          </p>
+        </section>
+
+        <section class="card timeline">
+          <div class="timeline-header">
+            <h2>Your timeline</h2>
+            <span id="status-pill" class="pill">Waiting for sign-in</span>
+          </div>
+          <div id="timeline" class="timeline-list"></div>
+        </section>
+      </main>
+    </div>
+
+    <template id="post-template">
+      <article class="post">
+        <div class="post-meta">
+          <div>
+            <p class="post-author"></p>
+            <p class="post-handle"></p>
+          </div>
+          <time class="post-date"></time>
+        </div>
+        <p class="post-text"></p>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,248 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, sans-serif;
+  --bg: #f6f7fb;
+  --card: #ffffff;
+  --text: #1d1f29;
+  --muted: #5b6270;
+  --accent: #3763f4;
+  --accent-dark: #2847b8;
+  --border: #e4e8f0;
+  --shadow: 0 24px 48px rgba(30, 40, 70, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 32px;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--accent);
+  margin-bottom: 12px;
+}
+
+.hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin-bottom: 12px;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+  max-width: 560px;
+}
+
+.hero-card {
+  background: linear-gradient(140deg, #3758f4, #5a8cff);
+  color: white;
+  padding: 24px 28px;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  min-width: 240px;
+}
+
+.hero-card .label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 14px;
+  opacity: 0.85;
+}
+
+.hero-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(320px, 1.2fr);
+  gap: 28px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.card h2 {
+  margin-bottom: 10px;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-bottom: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.field span,
+.field legend {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"] {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  background: #fff;
+}
+
+input:focus {
+  outline: 2px solid rgba(55, 99, 244, 0.4);
+  border-color: var(--accent);
+}
+
+.radio-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.radio {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.primary {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 12px 18px;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.primary:hover {
+  background: var(--accent-dark);
+}
+
+.footnote {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 16px;
+}
+
+.timeline {
+  min-height: 400px;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.pill {
+  background: #f0f3ff;
+  color: #3559d6;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.post {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: #fafbff;
+}
+
+.post-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.post-author {
+  font-weight: 600;
+}
+
+.post-handle,
+.post-date {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.post-text {
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 40px 0;
+}
+
+.error {
+  color: #b3261e;
+  background: #ffeceb;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .content {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation

- Replace the previous Python CLI timeline reader with a polished web app / website experience per the UI request.  
- Provide an in-browser flow that asks whether the user is caught up on Indiana Pacers games and hides potential spoilers when requested.  
- Keep authentication and timeline fetching minimal and temporary (session-only) so the app can run from a local static server.

### Description

- Remove the Python CLI and requirements and add a single-page web app composed of `index.html`, `styles.css`, and `app.js`.  
- Implement client-side session creation (`com.atproto.server.createSession`), timeline fetch (`app.bsky.feed.getTimeline`), and Pacers spoiler filtering using a small `PACERS_KEYWORDS` list.  
- Add a clean UI with a sign-in form, a caught-up radio prompt, a timeline list (template-driven), and status/error states.  
- Update `README.md` with quick-start instructions for serving the static site locally.

### Testing

- Started a local static server with `python3 -m http.server 5173` and verified the app was served successfully.  
- Captured a visual smoke test with Playwright (Firefox) which produced a screenshot saved as `artifacts/boomsky.png`.  
- A Playwright Chromium run failed with a SIGSEGV during headless launch, reported by the test run.  
- No automated unit or integration tests were added for the new client-side code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967038c505883309a1e6a25ebffbd32)