### PR TITLE
Filter timeline replies to only show those to followed users (and UI/embed rendering improvements)

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,11 +32,15 @@ const PACERS_BLOCKED_HANDLES = new Set([
   "tonyreast.bsky.social",
   "ipacers.bsky.social",
 ]);
+const DEFAULT_AVATAR = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80"><rect width="80" height="80" rx="40" fill="#dbe2f8"/><path d="M40 42c8.8 0 16-7.2 16-16S48.8 10 40 10s-16 7.2-16 16 7.2 16 16 16zm0 8c-13.3 0-24 10.7-24 24h48c0-13.3-10.7-24-24-24z" fill="#8aa0d6"/></svg>',
+)}`;
 
 const form = document.getElementById("credentials-form");
 const timeline = document.getElementById("timeline");
 const statusPill = document.getElementById("status-pill");
 const postTemplate = document.getElementById("post-template");
+let currentHandle = "";
 
 const setStatus = (text) => {
   statusPill.textContent = text;
@@ -71,6 +75,280 @@ const formatDate = (value) => {
   return date.toLocaleString();
 };
 
+const buildTextSegments = (text, facets = []) => {
+  if (!facets.length) {
+    return null;
+  }
+
+  const encoder = new TextEncoder();
+  const map = [];
+  let byteIndex = 0;
+  let stringIndex = 0;
+  for (const char of text) {
+    const bytes = encoder.encode(char).length;
+    map.push({
+      startByte: byteIndex,
+      endByte: byteIndex + bytes,
+      startIndex: stringIndex,
+      endIndex: stringIndex + char.length,
+    });
+    byteIndex += bytes;
+    stringIndex += char.length;
+  }
+
+  const getStringIndex = (targetByte) => {
+    for (const entry of map) {
+      if (targetByte <= entry.endByte) {
+        return targetByte === entry.endByte ? entry.endIndex : entry.startIndex;
+      }
+    }
+    return text.length;
+  };
+
+  const linkFacets = facets
+    .map((facet) => {
+      const link = facet.features?.find(
+        (feature) => feature.$type === "app.bsky.richtext.facet#link",
+      );
+      if (!link) {
+        return null;
+      }
+      return {
+        start: getStringIndex(facet.index.byteStart),
+        end: getStringIndex(facet.index.byteEnd),
+        uri: link.uri,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.start - b.start);
+
+  if (!linkFacets.length) {
+    return null;
+  }
+
+  const fragments = [];
+  let cursor = 0;
+  linkFacets.forEach((facet) => {
+    if (facet.start > cursor) {
+      fragments.push({ text: text.slice(cursor, facet.start) });
+    }
+    fragments.push({
+      text: text.slice(facet.start, facet.end),
+      link: facet.uri,
+    });
+    cursor = facet.end;
+  });
+  if (cursor < text.length) {
+    fragments.push({ text: text.slice(cursor) });
+  }
+
+  return fragments;
+};
+
+const linkifyText = (text) => {
+  const regex = /(https?:\/\/[^\s]+)/g;
+  const parts = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ text: text.slice(lastIndex, match.index) });
+    }
+    parts.push({ text: match[0], link: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ text: text.slice(lastIndex) });
+  }
+
+  return parts;
+};
+
+const renderPostText = (container, text, facets) => {
+  container.textContent = "";
+  const segments = buildTextSegments(text, facets) || linkifyText(text);
+  segments.forEach((segment) => {
+    if (segment.link) {
+      const anchor = document.createElement("a");
+      anchor.href = segment.link;
+      anchor.textContent = segment.text;
+      anchor.target = "_blank";
+      anchor.rel = "noopener noreferrer";
+      container.appendChild(anchor);
+    } else {
+      container.appendChild(document.createTextNode(segment.text));
+    }
+  });
+};
+
+const renderImages = (images, container) => {
+  if (!images?.length) {
+    return;
+  }
+  const media = document.createElement("div");
+  media.className = "post-media";
+  images.forEach((image) => {
+    const img = document.createElement("img");
+    img.src = image.thumb || image.fullsize || "";
+    img.alt = image.alt || "Post image";
+    media.appendChild(img);
+  });
+  container.appendChild(media);
+};
+
+const renderExternalCard = (external, container) => {
+  if (!external) {
+    return;
+  }
+  const card = document.createElement("a");
+  card.className = "link-card";
+  card.href = external.uri;
+  card.target = "_blank";
+  card.rel = "noopener noreferrer";
+
+  if (external.thumb) {
+    const thumb = document.createElement("img");
+    thumb.src = external.thumb;
+    thumb.alt = external.title || "External preview";
+    card.appendChild(thumb);
+  }
+
+  const content = document.createElement("div");
+  const title = document.createElement("h4");
+  title.textContent = external.title || "External link";
+  const desc = document.createElement("p");
+  desc.textContent = external.description || "";
+  const url = document.createElement("span");
+  let host = external.uri;
+  try {
+    host = new URL(external.uri).hostname;
+  } catch (error) {
+    host = external.uri;
+  }
+  url.textContent = host;
+
+  content.appendChild(title);
+  content.appendChild(desc);
+  content.appendChild(url);
+  card.appendChild(content);
+
+  container.appendChild(card);
+};
+
+const buildPostUrl = (record) => {
+  const handle = record?.author?.handle;
+  const uri = record?.uri;
+  if (!handle || !uri) {
+    return null;
+  }
+  const rkey = uri.split("/").pop();
+  if (!rkey) {
+    return null;
+  }
+  return `https://bsky.app/profile/${handle}/post/${rkey}`;
+};
+
+const renderQuotedPost = (record, container) => {
+  if (!record) {
+    return;
+  }
+
+  if (record.$type?.includes("viewNotFound")) {
+    const missing = document.createElement("div");
+    missing.className = "quote-card quote-unavailable";
+    missing.textContent = "Quoted post unavailable.";
+    container.appendChild(missing);
+    return;
+  }
+
+  if (record.$type?.includes("viewBlocked")) {
+    const blocked = document.createElement("div");
+    blocked.className = "quote-card quote-unavailable";
+    blocked.textContent = "Quoted post blocked.";
+    container.appendChild(blocked);
+    return;
+  }
+
+  const cardTag = buildPostUrl(record) ? "a" : "div";
+  const quoteCard = document.createElement(cardTag);
+  quoteCard.className = "quote-card";
+  if (cardTag === "a") {
+    quoteCard.href = buildPostUrl(record);
+    quoteCard.target = "_blank";
+    quoteCard.rel = "noopener noreferrer";
+  }
+
+  const meta = document.createElement("div");
+  meta.className = "quote-meta";
+  const avatar = document.createElement("img");
+  avatar.className = "quote-avatar";
+  avatar.src = record.author?.avatar || DEFAULT_AVATAR;
+  avatar.alt = record.author?.displayName || record.author?.handle || "User avatar";
+  const author = document.createElement("div");
+  author.className = "quote-author";
+  author.textContent = record.author?.displayName || "Unknown";
+  const handle = document.createElement("span");
+  handle.className = "quote-handle";
+  handle.textContent = record.author?.handle ? `@${record.author.handle}` : "@unknown";
+  const date = document.createElement("span");
+  date.className = "quote-date";
+  date.textContent = formatDate(record.value?.createdAt);
+
+  meta.appendChild(avatar);
+  meta.appendChild(author);
+  meta.appendChild(handle);
+  meta.appendChild(date);
+
+  const text = document.createElement("div");
+  text.className = "quote-text";
+  renderPostText(text, record.value?.text || "", record.value?.facets || []);
+
+  quoteCard.appendChild(meta);
+  if (record.value?.text) {
+    quoteCard.appendChild(text);
+  }
+
+  if (record.embeds?.length) {
+    const nested = document.createElement("div");
+    nested.className = "quote-embed";
+    renderEmbed(record.embeds[0], nested);
+    quoteCard.appendChild(nested);
+  }
+
+  container.appendChild(quoteCard);
+};
+
+const extractQuotedRecord = (embed) => {
+  if (!embed) {
+    return null;
+  }
+
+  if (embed.$type?.includes("recordWithMedia")) {
+    return embed.record?.record || embed.record || null;
+  }
+
+  if (embed.$type?.includes("record")) {
+    return embed.record || embed.record?.record || null;
+  }
+
+  return null;
+};
+
+const renderEmbed = (embed, container) => {
+  if (!embed) {
+    return;
+  }
+  const images = embed.images || embed.media?.images;
+  const external = embed.external || embed.record?.external;
+  const record = extractQuotedRecord(embed);
+
+  renderImages(images, container);
+  renderExternalCard(external, container);
+  renderQuotedPost(record, container);
+};
+
 const renderPosts = (posts) => {
   timeline.innerHTML = "";
   if (posts.length === 0) {
@@ -84,10 +362,19 @@ const renderPosts = (posts) => {
     const author = post.author || {};
     const clone = postTemplate.content.cloneNode(true);
 
+    const avatar = clone.querySelector(".post-avatar");
+    avatar.src = author.avatar || DEFAULT_AVATAR;
+    avatar.alt = author.displayName || author.handle || "User avatar";
+
     clone.querySelector(".post-author").textContent = author.displayName || "Unknown";
     clone.querySelector(".post-handle").textContent = `@${author.handle || "unknown"}`;
     clone.querySelector(".post-date").textContent = formatDate(record.createdAt);
-    clone.querySelector(".post-text").textContent = record.text || "";
+
+    const textContainer = clone.querySelector(".post-text");
+    renderPostText(textContainer, record.text || "", record.facets || []);
+
+    const embedContainer = clone.querySelector(".post-embed");
+    renderEmbed(post.embed, embedContainer);
 
     timeline.appendChild(clone);
   });
@@ -129,11 +416,28 @@ const fetchTimeline = async (token, limit) => {
 };
 
 const filterTimeline = (feed, hidePacers) => {
+  const shouldIncludeReply = (item) => {
+    if (!item.reply?.parent) {
+      return true;
+    }
+    const parentAuthor = item.reply.parent.author;
+    if (!parentAuthor) {
+      return true;
+    }
+    if (parentAuthor.handle && parentAuthor.handle === currentHandle) {
+      return true;
+    }
+    return parentAuthor.viewer?.following === true;
+  };
+
   if (!hidePacers) {
-    return feed;
+    return feed.filter(shouldIncludeReply);
   }
 
   return feed.filter((item) => {
+    if (!shouldIncludeReply(item)) {
+      return false;
+    }
     const text = item.post?.record?.text || "";
     return !containsPacersSpoiler(text);
   });
@@ -157,6 +461,7 @@ form.addEventListener("submit", async (event) => {
   }
 
   try {
+    currentHandle = handle;
     const token = await createSession(handle, appPassword);
     const feed = await fetchTimeline(token, limit);
     const filtered = filterTimeline(feed, !caughtUp);

--- a/index.html
+++ b/index.html
@@ -13,97 +13,169 @@
     />
   </head>
   <body>
-    <div class="page">
-      <header class="hero">
-        <div>
-          <p class="eyebrow">BoomSky</p>
-          <h1>Bluesky with spoiler control</h1>
+    <div class="app-shell">
+      <header class="topbar">
+        <div class="brand">
+          <span class="logo-dot"></span>
+          <div>
+            <p class="eyebrow">BoomSky</p>
+            <h1>Bluesky with spoiler control</h1>
+          </div>
+        </div>
+        <label class="search">
+          <span>Search</span>
+          <input type="search" placeholder="Search posts, handles, lists" disabled />
+        </label>
+        <div class="top-actions">
+          <button class="ghost">New post</button>
+          <button class="primary">Account</button>
+        </div>
+      </header>
+
+      <div class="layout">
+        <aside class="sidebar">
           <p class="subtitle">
             Check in on your Pacers watch status before pulling in your timeline, so you
             can avoid spoilers when you&apos;re behind.
           </p>
-        </div>
-        <div class="hero-card">
-          <p class="label">Pacers spoiler shield</p>
-          <p class="hero-value">Active when you&apos;re not caught up</p>
-        </div>
-      </header>
-
-      <main class="content">
-        <section class="card">
-          <h2>Sign in to Bluesky</h2>
-          <p class="muted">
-            Use an app password from your Bluesky account settings. We only use it to
-            fetch your timeline in this session.
-          </p>
-          <form id="credentials-form">
-            <label class="field">
-              <span>Handle</span>
-              <input
-                type="text"
-                name="handle"
-                placeholder="you.bsky.social"
-                autocomplete="username"
-                required
-              />
-            </label>
-            <label class="field">
-              <span>App password</span>
-              <input
-                type="password"
-                name="appPassword"
-                placeholder="xxxx-xxxx-xxxx-xxxx"
-                autocomplete="current-password"
-                required
-              />
-            </label>
-            <label class="field">
-              <span>Timeline posts to fetch</span>
-              <input type="number" name="limit" min="5" max="100" value="30" />
-            </label>
-
-            <fieldset class="field">
-              <legend>Are you up-to-date on Pacers games?</legend>
-              <div class="radio-row">
-                <label class="radio">
-                  <input type="radio" name="caughtUp" value="yes" />
-                  <span>Yes, I&apos;m caught up</span>
-                </label>
-                <label class="radio">
-                  <input type="radio" name="caughtUp" value="no" checked />
-                  <span>No, hide spoilers</span>
-                </label>
-              </div>
-            </fieldset>
-
-            <button type="submit" class="primary">Load timeline</button>
-          </form>
-          <p class="footnote">
-            Tip: if Bluesky&apos;s API blocks browser requests, run this page from a local
-            static server (e.g. <code>python3 -m http.server</code>).
-          </p>
-        </section>
-
-        <section class="card timeline">
-          <div class="timeline-header">
-            <h2>Your timeline</h2>
-            <span id="status-pill" class="pill">Waiting for sign-in</span>
+          <nav class="nav">
+            <a class="nav-item active" href="#">Home</a>
+            <a class="nav-item" href="#">Discover</a>
+            <a class="nav-item" href="#">Lists</a>
+            <a class="nav-item" href="#">Notifications</a>
+            <a class="nav-item" href="#">Saved</a>
+          </nav>
+          <div class="shield-card">
+            <p class="label">Pacers spoiler shield</p>
+            <p class="hero-value">Active when you&apos;re not caught up</p>
+            <p class="muted">Toggle the shield in the sign-in panel.</p>
           </div>
-          <div id="timeline" class="timeline-list"></div>
-        </section>
-      </main>
+        </aside>
+
+        <main class="feed">
+          <section class="composer">
+            <div class="composer-head">
+              <div class="avatar-sample">B</div>
+              <div>
+                <h2>What&apos;s happening?</h2>
+                <p class="muted">
+                  Preview your timeline with spoiler filters, media previews, and
+                  embedded article cards.
+                </p>
+              </div>
+            </div>
+            <div class="composer-actions">
+              <button class="ghost">Add photo</button>
+              <button class="ghost">Add link</button>
+              <button class="ghost">Spoiler tags</button>
+            </div>
+          </section>
+
+          <section class="card timeline">
+            <div class="timeline-header">
+              <div>
+                <h2>Your timeline</h2>
+                <p class="muted">Images, rich links, and embeds appear below.</p>
+              </div>
+              <span id="status-pill" class="pill">Waiting for sign-in</span>
+            </div>
+            <div id="timeline" class="timeline-list"></div>
+          </section>
+        </main>
+
+        <aside class="panel">
+          <section class="card">
+            <h2>Sign in to Bluesky</h2>
+            <p class="muted">
+              Use an app password from your Bluesky account settings. We only use it to
+              fetch your timeline in this session.
+            </p>
+            <form id="credentials-form">
+              <label class="field">
+                <span>Handle</span>
+                <input
+                  type="text"
+                  name="handle"
+                  placeholder="you.bsky.social"
+                  value="excitedstate.bsky.social"
+                  autocomplete="username"
+                  readonly
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>App password</span>
+                <input
+                  type="password"
+                  name="appPassword"
+                  placeholder="xxxx-xxxx-xxxx-xxxx"
+                  autocomplete="current-password"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span>Timeline posts to fetch</span>
+                <input type="number" name="limit" min="5" max="100" value="30" />
+              </label>
+
+              <fieldset class="field">
+                <legend>Are you up-to-date on Pacers games?</legend>
+                <div class="radio-row">
+                  <label class="radio">
+                    <input type="radio" name="caughtUp" value="yes" />
+                    <span>Yes, I&apos;m caught up</span>
+                  </label>
+                  <label class="radio">
+                    <input type="radio" name="caughtUp" value="no" checked />
+                    <span>No, hide spoilers</span>
+                  </label>
+                </div>
+              </fieldset>
+
+              <button type="submit" class="primary">Load timeline</button>
+            </form>
+            <p class="footnote">
+              Tip: if Bluesky&apos;s API blocks browser requests, run this page from a local
+              static server (e.g. <code>python3 -m http.server</code>).
+            </p>
+          </section>
+
+          <section class="card tips">
+            <h3>Timeline highlights</h3>
+            <ul>
+              <li>Image grids show spoiler-free photo previews.</li>
+              <li>External links appear as article cards.</li>
+              <li>Embedded posts keep conversation context.</li>
+            </ul>
+          </section>
+        </aside>
+      </div>
     </div>
 
     <template id="post-template">
       <article class="post">
-        <div class="post-meta">
-          <div>
-            <p class="post-author"></p>
-            <p class="post-handle"></p>
+        <img class="post-avatar" alt="" />
+        <div class="post-body">
+          <div class="post-meta">
+            <div class="post-author-group">
+              <span class="post-author"></span>
+              <span class="post-handle"></span>
+              <span class="post-separator">·</span>
+              <time class="post-date"></time>
+            </div>
+            <button class="post-menu" type="button" aria-label="Post actions">
+              •••
+            </button>
           </div>
-          <time class="post-date"></time>
+          <div class="post-text"></div>
+          <div class="post-embed"></div>
+          <div class="post-actions">
+            <span>💬 Reply</span>
+            <span>🔁 Repost</span>
+            <span>❤️ Like</span>
+            <span>↗️ Share</span>
+          </div>
         </div>
-        <p class="post-text"></p>
       </article>
     </template>
 

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,16 @@
 :root {
   color-scheme: light;
   font-family: "Inter", system-ui, sans-serif;
-  --bg: #f6f7fb;
+  --bg: #eef2f8;
   --card: #ffffff;
-  --text: #1d1f29;
-  --muted: #5b6270;
-  --accent: #3763f4;
-  --accent-dark: #2847b8;
-  --border: #e4e8f0;
-  --shadow: 0 24px 48px rgba(30, 40, 70, 0.08);
+  --text: #0f172a;
+  --muted: #576072;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --border: #e1e7f0;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  --soft: #f8fafc;
+  --nav: #f3f6fc;
 }
 
 * {
@@ -23,18 +25,18 @@ body {
   min-height: 100vh;
 }
 
-.page {
-  max-width: 1100px;
+.app-shell {
+  max-width: 1250px;
   margin: 0 auto;
-  padding: 48px 24px 80px;
+  padding: 28px 24px 80px;
 }
 
-.hero {
+.topbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 32px;
-  margin-bottom: 48px;
+  gap: 24px;
+  margin-bottom: 24px;
 }
 
 .eyebrow {
@@ -46,49 +48,62 @@ body {
   margin-bottom: 12px;
 }
 
-.hero h1 {
-  font-size: clamp(2.2rem, 4vw, 3rem);
-  margin-bottom: 12px;
+.topbar h1 {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  margin-bottom: 4px;
 }
 
-.subtitle {
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-dot {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: radial-gradient(circle at top, #7aa6ff, #2563eb);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.35);
+}
+
+.search {
+  flex: 1;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
   color: var(--muted);
-  font-size: 1.05rem;
-  max-width: 560px;
 }
 
-.hero-card {
-  background: linear-gradient(140deg, #3758f4, #5a8cff);
-  color: white;
-  padding: 24px 28px;
-  border-radius: 20px;
-  box-shadow: var(--shadow);
-  min-width: 240px;
+.search input {
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--soft);
 }
 
-.hero-card .label {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  margin-bottom: 14px;
-  opacity: 0.85;
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-.hero-value {
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.content {
+.layout {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(320px, 1.2fr);
-  gap: 28px;
+  grid-template-columns: minmax(220px, 1fr) minmax(420px, 2.4fr) minmax(
+      260px,
+      1fr
+    );
+  gap: 24px;
+  align-items: start;
 }
 
 .card {
   background: var(--card);
   border-radius: 20px;
-  padding: 28px;
+  padding: 24px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 }
@@ -100,7 +115,136 @@ body {
 .muted {
   color: var(--muted);
   font-size: 0.95rem;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 24px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  text-decoration: none;
+  color: var(--text);
+  background: var(--nav);
+  font-weight: 600;
+}
+
+.nav-item.active {
+  background: #dbe6ff;
+  color: #1d4ed8;
+}
+
+.shield-card {
+  background: linear-gradient(130deg, #2f6af5, #7aa7ff);
+  color: white;
+  padding: 20px;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 10px;
+  opacity: 0.85;
+}
+
+.hero-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.shield-card .muted {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 0;
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.composer {
+  background: var(--card);
+  border-radius: 22px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.composer-head {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.avatar-sample {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: #2c4df2;
+  color: white;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.composer-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.tips ul {
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.tips li {
+  padding-left: 18px;
+  position: relative;
+}
+
+.tips li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-weight: 700;
 }
 
 .field {
@@ -118,7 +262,8 @@ body {
 
 input[type="text"],
 input[type="password"],
-input[type="number"] {
+input[type="number"],
+input[type="search"] {
   padding: 12px 14px;
   border-radius: 12px;
   border: 1px solid var(--border);
@@ -161,6 +306,16 @@ input:focus {
   background: var(--accent-dark);
 }
 
+.ghost {
+  border: 1px solid var(--border);
+  background: white;
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .footnote {
   font-size: 0.85rem;
   color: var(--muted);
@@ -176,6 +331,7 @@ input:focus {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 18px;
+  gap: 16px;
 }
 
 .pill {
@@ -194,10 +350,12 @@ input:focus {
 }
 
 .post {
+  display: flex;
+  gap: 14px;
   border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 16px 18px;
-  background: #fafbff;
+  border-radius: 18px;
+  padding: 18px;
+  background: #f7f9ff;
 }
 
 .post-meta {
@@ -211,8 +369,17 @@ input:focus {
   font-weight: 600;
 }
 
+.post-author-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
 .post-handle,
-.post-date {
+.post-date,
+.post-separator {
   color: var(--muted);
   font-size: 0.85rem;
 }
@@ -220,6 +387,146 @@ input:focus {
 .post-text {
   white-space: pre-wrap;
   line-height: 1.5;
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
+.post-text a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.post-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #d9e2f5;
+}
+
+.post-body {
+  flex: 1;
+}
+
+.post-menu {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.post-embed {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.post-media {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.post-media img {
+  width: 100%;
+  border-radius: 14px;
+  object-fit: cover;
+  aspect-ratio: 4 / 3;
+}
+
+.link-card {
+  display: flex;
+  gap: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: white;
+  padding: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.link-card img {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: var(--nav);
+}
+
+.link-card h4 {
+  font-size: 0.95rem;
+  margin-bottom: 6px;
+}
+
+.link-card p {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.link-card span {
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.post-actions {
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.quote-card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 12px;
+  background: white;
+  text-decoration: none;
+  color: inherit;
+  display: grid;
+  gap: 8px;
+}
+
+.quote-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.quote-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.quote-author {
+  font-weight: 600;
+}
+
+.quote-handle,
+.quote-date {
+  color: var(--muted);
+}
+
+.quote-text {
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.quote-embed .post-media {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.quote-unavailable {
+  color: var(--muted);
+  font-size: 0.85rem;
 }
 
 .empty {
@@ -236,13 +543,22 @@ input:focus {
   font-size: 0.9rem;
 }
 
-@media (max-width: 900px) {
-  .hero {
-    flex-direction: column;
-    align-items: flex-start;
+@media (max-width: 1100px) {
+  .layout {
+    grid-template-columns: 1fr;
   }
 
-  .content {
-    grid-template-columns: 1fr;
+  .sidebar,
+  .panel {
+    order: 2;
+  }
+
+  .feed {
+    order: 1;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent replies from people you follow appearing in the feed when they are replying to authors you do not follow by evaluating reply parent authors against the signed-in handle and following state.
- Improve robustness and fidelity of post rendering so quoted posts, images, external link cards, and rich-text links render consistently.
- Refresh the UI layout and styling to better present avatars, post metadata, embeds, and timeline cards.

### Description
- Track the signed-in handle in `currentHandle` and add a `shouldIncludeReply` check inside `filterTimeline` to only include replies when the reply has no parent, the parent author is the signed-in handle, or the parent author is followed (`parentAuthor.viewer?.following`).
- Add rich-text/link rendering helpers `buildTextSegments`, `linkifyText`, and `renderPostText`, plus media/embed helpers `renderImages`, `renderExternalCard`, `buildPostUrl`, `renderQuotedPost`, `extractQuotedRecord`, and `renderEmbed`, and wire these into `renderPosts` to render avatars, text facets, embeds, and quoted posts.
- Set `currentHandle` on form submit before creating a session and fetching the timeline so reply filtering uses the signed-in handle during filtering.
- Apply a UI overhaul by updating `index.html` and `styles.css` to introduce an `app-shell` layout, updated timeline/post template, and new visual styles for avatars, cards, quote blocks, and link previews.

### Testing
- No automated tests were executed for this front-end change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671ca1a0908330a8e3543f231954f7)